### PR TITLE
Section four/navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,3 +37,9 @@
 .center {
   text-align: center;
 }
+
+.nav {
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -2,12 +2,14 @@ import './App.css';
 import About from './components/About';
 import Contact from './components/Contact';
 import Home from './components/Home';
+import Nav from './components/Nav';
 
 import Route from './routing/Route';
 
 function App() {
   return (
     <div className="App">
+      <Nav />
       <h1 className="headline">Routing in React</h1>
       <Route path="/">
         <Home />

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,11 +1,13 @@
 import React from 'react';
 
+import Link from '../routing/Link';
+
 const Nav = () => {
   return (
     <div className="nav">
-      <a href="/">Home</a>
-      <a href="/about">About</a>
-      <a href="/contact">Contact</a>
+      <Link href="/">Home</Link>
+      <Link href="/about">About</Link>
+      <Link href="/contact">Contact</Link>
     </div>
   );
 };

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Nav = () => {
+  return (
+    <div className="nav">
+      <a href="/">Home</a>
+      <a href="/about">About</a>
+      <a href="/contact">Contact</a>
+    </div>
+  );
+};
+
+export default Nav;

--- a/src/routing/Link.js
+++ b/src/routing/Link.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Link = ({ href, className = 'link', children }) => {
+  return (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  );
+};
+
+export default Link;

--- a/src/routing/Link.js
+++ b/src/routing/Link.js
@@ -1,8 +1,14 @@
 import React from 'react';
 
 const Link = ({ href, className = 'link', children }) => {
+  // custom click handler
+  const onClick = (e) => {
+    e.preventDefault();
+    window.history.pushState({}, '', href);
+  };
+
   return (
-    <a href={href} className={className}>
+    <a onClick={onClick} href={href} className={className}>
       {children}
     </a>
   );

--- a/src/routing/Route.js
+++ b/src/routing/Route.js
@@ -1,7 +1,6 @@
 //import React from 'react';
 
 const Route = ({ children, path }) => {
-  console.log(children);
   return window.location.pathname === path ? children : null;
 };
 


### PR DESCRIPTION
We've built the Route component that knows how to read a pathname, and when we manually visit a URL with an attached pathname that is "/about", "/", or "/contact" the Route will display the correct child. It does this by reading the current `pathname` maintained by the browser environment, then displaying the component it finds on the `children` prop corresponding to that path. 

Next, we discussed basic navigation, an expected feature on any website. We implemented navigation with the Anchor element, `<a>`. But there are problems with the default behavior of these elements in the browser, specifically when it comes to building apps with React. The good news is that using standard patterns and approaches in both React and JS, we can work around these behaviors and implement our own, custom logic. 

Our custom Link component uses a special click handler to prevent the full-page refresh with the `preventDefault()` method. Then it takes this opportunity to update the session history with a call to the `pushState` method of the browser History object. This successfully updates the current URL... but nothing else happens. The page doesn't re-render with the correct component until we manually enter the URL. 

We'll discuss why this is, and how to fix it, in the next section. 
